### PR TITLE
Step: Public API and Reflection

### DIFF
--- a/memui.go
+++ b/memui.go
@@ -1,6 +1,9 @@
 package memui
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+)
 
 type MemUI struct {
 	memObjects map[string][]interface{}
@@ -12,15 +15,31 @@ func New() *MemUI {
 	}
 }
 
+func (mui *MemUI) addValue(typeName string, obj interface{}) error {
+	if _, ok := mui.memObjects[typeName]; !ok {
+		mui.memObjects[typeName] = make([]interface{}, 0)
+	}
+
+	mui.memObjects[typeName] = append(mui.memObjects[typeName], obj)
+	return nil
+}
+
+func (mui *MemUI) registerValue(obj interface{}) error {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr {
+		return fmt.Errorf("object must be a pointer")
+	}
+
+	typeName := v.Type().String()
+	return mui.addValue(typeName, obj)
+}
+
 func (mui *MemUI) Register(objs ...interface{}) error {
 	for _, obj := range objs {
-		typeName := reflect.TypeOf(obj).String()
-
-		if _, ok := mui.memObjects[typeName]; !ok {
-			mui.memObjects[typeName] = make([]interface{}, 0)
+		err := mui.registerValue(obj)
+		if err != nil {
+			return err
 		}
-
-		mui.memObjects[typeName] = append(mui.memObjects[typeName], obj)
 	}
 
 	return nil

--- a/testapp/main.go
+++ b/testapp/main.go
@@ -18,7 +18,11 @@ func main() {
 	p2 := Person{"Mary", 25}
 
 	mui := memui.New()
-	mui.Register(p1, p2)
 
-	fmt.Println(mui.ListValues("main.Person"))
+	err := mui.Register(&p1, &p2)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	fmt.Println(mui.ListValues("*main.Person"))
 }


### PR DESCRIPTION
Change the `Register` method to accept only pointer objects by using reflection.